### PR TITLE
Scaffold modules

### DIFF
--- a/lua/dorm/init.lua
+++ b/lua/dorm/init.lua
@@ -66,6 +66,9 @@ function dorm.setup(cfg)
       end,
     })
   end
+
+  -- Call Mod.load_modules to load all modules
+  mod.load_modules()
 end
 
 --- This function gets called upon entering a .dorm file and loads all of the user-defined mod.

--- a/lua/dorm/mod/init.lua
+++ b/lua/dorm/mod/init.lua
@@ -837,4 +837,25 @@ function Mod.send_event(recipient, event)
   end
 end
 
+--- Load all modules in the `lua/dorm/mod` directory.
+function Mod.load_modules()
+  local dir = "lua/dorm/mod"
+  local handle = vim.loop.fs_scandir(dir)
+  if not handle then
+    return
+  end
+
+  while true do
+    local name, type = vim.loop.fs_scandir_next(handle)
+    if not name then
+      break
+    end
+
+    if type == "file" and name:match("module%.lua$") then
+      local module_name = name:gsub("%.lua$", "")
+      Mod.load_module(module_name)
+    end
+  end
+end
+
 return Mod


### PR DESCRIPTION
Add functionality to load all modules in the `lua/dorm/mod` directory.

* **`lua/dorm/mod/init.lua`**
  - Add `Mod.load_modules` function to load all modules in the `lua/dorm/mod` directory.
  - Use `vim.loop.fs_scandir` to iterate over the files in the directory.
  - Call `Mod.load_module` for each file that matches the pattern `module.lua`.

* **`lua/dorm/init.lua`**
  - Call `Mod.load_modules` in the `dorm.setup` function to load all modules.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/clpi/dorm.lua/pull/3?shareId=a79ba9ed-99f1-42ec-b454-76565e66c684).

## Summary by Sourcery

Add functionality to automatically load all modules in the 'lua/dorm/mod' directory during the setup process by introducing a new function 'Mod.load_modules' and integrating it into 'dorm.setup'.

New Features:
- Introduce a function to load all modules in the 'lua/dorm/mod' directory using 'vim.loop.fs_scandir'.

Enhancements:
- Enhance the 'dorm.setup' function to automatically load all modules by calling 'Mod.load_modules'.